### PR TITLE
kvdb:add API exitprop for exit kvdbd server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,8 @@ ifneq ($(CONFIG_KVDB_DIRECT),)
 CSRCS += kvdb/direct.c
 else
 CSRCS += kvdb/client.c
+MAINSRC += kvdb/exitprop.c
+PROGNAME += exitprop
 endif # CONFIG_KVDB_DIRECT
 CSRCS += kvdb/common.c kvdb/system_properties.c
 MAINSRC  += kvdb/setprop.c kvdb/getprop.c

--- a/include/kvdb.h
+++ b/include/kvdb.h
@@ -56,6 +56,12 @@ int property_commit(void);
 int property_reload(void);
 
 /**
+ * @brief Exit the kvdb service.
+ * @return On success returns 0, -errno otherwise.
+ */
+int property_exit(void);
+
+/**
  * @brief Wait the monitored key until its value updated or key deleted
  * @param[in] key the monitored key string, support fnmatch pattern
  * @param[in] the length of the newvalue

--- a/kvdb/client.c
+++ b/kvdb/client.c
@@ -787,3 +787,45 @@ int property_reload(void)
     close(fd);
     return ret;
 }
+
+/****************************************************************************
+ * Name: property_exit
+ *
+ * Description:
+ *   Exit Kvdb Server
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   On success returns 0.
+ *   On failure returns -errno.
+ *
+ ****************************************************************************/
+
+int property_exit(void)
+{
+    int fd = property_connect();
+    int ret;
+    int value;
+
+    if (fd < 0)
+        return fd;
+
+    ret = send(fd, "E", 1, 0);
+    if (ret < 0) {
+        KVERR("send error %d\n", errno);
+        ret = -errno;
+        goto out;
+    }
+
+    ret = recv(fd, &value, sizeof(value), 0);
+    if (ret < sizeof(value)) {
+        KVERR("recv error %d, ret %d\n", errno, ret);
+        ret = -errno;
+    }
+
+out:
+    close(fd);
+    return ret;
+}

--- a/kvdb/direct.c
+++ b/kvdb/direct.c
@@ -206,3 +206,19 @@ int property_reload(void)
 {
     return 0;
 }
+
+/****************************************************************************
+ * Name: property_exit
+ *
+ * Description:
+ *   Exit Kvdb Server (Dummy Function)
+ *
+ * Input Parameters:
+ *   None
+ *
+ ****************************************************************************/
+
+int property_exit(void)
+{
+    return 0;
+}

--- a/kvdb/exitprop.c
+++ b/kvdb/exitprop.c
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2020 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <kvdb.h>
+
+int main(int argc, char* argv[])
+{
+    return property_exit();
+}

--- a/kvdb/server.c
+++ b/kvdb/server.c
@@ -53,6 +53,7 @@ typedef struct kvdb_server {
     struct kvdb* kvdb;
     int fd[KVFD_COUNT];
     int efd;
+    bool running;
     kvdb_monitor_head head;
 } kvdb_server;
 
@@ -453,6 +454,13 @@ static bool kvdb_client(kvdb_server* server, int fd)
         free(msg);
         return false;
     }
+    case 'E': {
+        int ret = 0;
+        server->running = false;
+        kvdb_uninit(server->kvdb);
+        send(fd, &ret, sizeof(ret), 0);
+        break;
+    }
     }
 
 out:
@@ -482,8 +490,8 @@ static void kvdb_loop(kvdb_server* server)
     }
 
     time_t next = 0;
-
-    while (1) {
+    server->running = true;
+    while (server->running) {
         int timeout = -1;
 
         /* commit the change after timeout */
@@ -560,8 +568,6 @@ int main(int argc, char* argv[])
 
     kvdb_load(server.kvdb, CONFIG_KVDB_SOURCE_PATH, false);
     kvdb_loop(&server);
-    kvdb_uninit(server.kvdb);
-
 out:
     kvdb_unbind(server.fd);
     return -ret;


### PR DESCRIPTION
## Summary
  Added support for the Server exit capability
  1. Add new api property_exit()
  2. Add new command exitprop

## Impact
  Added an exitprop API

## Testing
  Test in qemu, it works fine.
