### PR TITLE
kvdb: use filekv over tmpfs as no-persist kv backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,13 +48,17 @@ if(CONFIG_SCHED_INSTRUMENTATION_DUMP
     else()
       list(APPEND CSRCS kvdb/client.c)
     endif()
-    list(APPEND CSRCS kvdb/common.c kvdb/system_properties.c)
+    list(APPEND CSRCS kvdb/common.c kvdb/system_properties.c kvdb/backend.c)
 
     if(CONFIG_KVDB_NVS)
       list(APPEND CSRCS kvdb/nvs.c)
     elseif(CONFIG_KVDB_UNQLITE)
       list(APPEND INCDIR ${NUTTX_APPS_DIR}/external/unqlite/unqlite)
       list(APPEND CSRCS kvdb/unqlite.c)
+    endif()
+
+    if(CONFIG_KVDB_FILE OR CONFIG_KVDB_TEMPORARY_STORAGE)
+      list(APPEND CSRCS kvdb/file.c)
     endif()
 
     if(CONFIG_KVDB_SERVER)

--- a/Kconfig
+++ b/Kconfig
@@ -112,9 +112,10 @@ config KVDB_SOURCE_PATH
 config KVDB_TEMPORARY_STORAGE
 	bool "enable non-persistent Key-value storage"
 	default !DEFAULT_SMALL
+	depends on FS_TMPFS
 
 choice
-	prompt "the storage method of Key-value"
+	prompt "the persistent storage method of Key-value"
 	default KVDB_UNQLITE
 
 config KVDB_UNQLITE
@@ -143,9 +144,8 @@ config KVDB_PERSIST_PATH
 	default "/dev/config" if KVDB_NVS
 
 config KVDB_TEMPORARY_PATH
-	string "non-persistent database path"
-	default "/tmp/temporary.db" if KVDB_UNQLITE
-	default "/dev/config_ram" if KVDB_NVS
+	string "non-persistent database directory path"
+	default "/tmp/db"
 	depends on KVDB_TEMPORARY_STORAGE
 
 endif # KVDB_DIRECT || KVDB_SERVER

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,8 @@ CSRCS += kvdb/client.c
 MAINSRC += kvdb/exitprop.c
 PROGNAME += exitprop
 endif # CONFIG_KVDB_DIRECT
-CSRCS += kvdb/common.c kvdb/system_properties.c
+
+CSRCS += kvdb/common.c kvdb/system_properties.c kvdb/backend.c
 MAINSRC  += kvdb/setprop.c kvdb/getprop.c
 PROGNAME += setprop getprop
 
@@ -51,9 +52,11 @@ CSRCS += kvdb/nvs.c
 else ifneq ($(CONFIG_KVDB_UNQLITE),)
 CFLAGS += ${INCDIR_PREFIX}$(APPDIR)/external/unqlite/unqlite
 CSRCS += kvdb/unqlite.c
-else ifneq ($(CONFIG_KVDB_FILE),)
-CSRCS += kvdb/file.c
 endif # CONFIG_KVDB_NVS
+
+ifneq ($(CONFIG_KVDB_FILE)$(CONFIG_KVDB_TEMPORARY_STORAGE),)
+CSRCS += kvdb/file.c
+endif # CONFIG_KVDB_FILE or CONFIG_KVDB_TEMPORARY_STORAGE
 
 ifneq ($(CONFIG_KVDB_QEMU_PROPERTIES),)
 MAINSRC  += kvdb/qemu_properties.c

--- a/kvdb/backend.c
+++ b/kvdb/backend.c
@@ -1,0 +1,283 @@
+/*
+ * Copyright (C) 2024 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <errno.h>
+#include <string.h>
+
+#include <kvdb.h>
+#include <sys/param.h>
+#include <sys/stat.h>
+
+#include "internal.h"
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static int kvdb_get_index(const char* key)
+{
+    if (strncmp(key, PERSIST_LABEL, PERSIST_LABEL_LEN) == 0) {
+        return KVDB_PERSIST;
+    } else {
+#ifdef CONFIG_KVDB_TEMPORARY_STORAGE
+        return KVDB_MEM;
+#else
+        return -EINVAL;
+#endif
+    }
+}
+
+static bool kvdb_kv_is_exist(struct kvdb* kvdb, const char* key,
+    size_t key_len, size_t val_len)
+{
+    return kvdb_get(kvdb, key, key_len, NULL, val_len) >= 0;
+}
+
+static bool kvdb_is_readonly(const char* key)
+{
+    return strncmp(key, "ro.", 3) == 0;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: kvdb_init
+ *
+ * Description:
+ *   init resource of nvs .
+ *
+ * Input Parameters:
+ *   kvdb    - Pointer to save filekv instance.
+ *
+ * Returned Value:
+ *   0 on success, -ERRNO errno code if error.
+ *
+ ****************************************************************************/
+
+int kvdb_init(struct kvdb** kvdb)
+{
+    int ret = kvdb_persist_init(kvdb);
+#ifdef CONFIG_KVDB_TEMPORARY_STORAGE
+    if (ret >= 0) {
+        ret = mkdir(CONFIG_KVDB_TEMPORARY_PATH, 0666);
+        if (ret < 0) {
+            ret = -errno;
+
+            /* Existing tmp dir is acceptable. */
+
+            if (ret == -EEXIST)
+                ret = 0;
+        }
+    }
+#endif
+    return ret;
+}
+
+/****************************************************************************
+ * Name: kvdb_uninit
+ *
+ * Description:
+ *   init resource of filekv .
+ *
+ * Input Parameters:
+ *   kvdb    - Pointer to save filekv instance.
+ *
+ * Returned Value:
+ *   0 on success, -ERRNO errno code if error.
+ *
+ ****************************************************************************/
+
+void kvdb_uninit(struct kvdb* kvdb)
+{
+    kvdb_persist_uninit(kvdb);
+}
+
+/****************************************************************************
+ * Name: kvdb_set
+ *
+ * Description:
+ *   key-value set.
+ *
+ * Input Parameters:
+ *   kvdb    - Pointer to save filekv instance.
+ *   key     - Pointer to key to set.
+ *   key_len - the length of the key
+ *   value   - Pointer to data to be saved
+ *   val_len - the length of the value
+ *   force   - unused parameter
+ *
+ * Returned Value:
+ *   0 on success, -ERRNO errno code if error.
+ *
+ ****************************************************************************/
+
+int kvdb_set(struct kvdb* kvdb, const char* key, size_t key_len,
+    const void* value, size_t val_len, bool force)
+{
+    int ret;
+
+    if (!force && kvdb_is_readonly(key) && kvdb_kv_is_exist(kvdb, key, key_len, val_len))
+        return -EPERM;
+
+    ret = kvdb_get_index(key);
+    switch (ret) {
+    case KVDB_PERSIST:
+        ret = kvdb_persist_set(kvdb, key, key_len, value, val_len, force);
+        break;
+#ifdef CONFIG_KVDB_TEMPORARY_STORAGE
+    case KVDB_MEM:
+        ret = kvdb_file_set(CONFIG_KVDB_TEMPORARY_PATH, key, value, val_len);
+        break;
+#endif
+    default:
+        ret = -EINVAL;
+        break;
+    }
+
+    return ret;
+}
+
+/****************************************************************************
+ * Name: kvdb_get
+ *
+ * Description:
+ *   key-value get.
+ *
+ * Input Parameters:
+ *   kvdb    - Pointer to save filekv instance.
+ *   key     - Pointer to key to get.
+ *   key_len - the length of the key
+ *   value   - Pointer to data to be get
+ *   val_len - the length of the value
+ *
+ * Returned Value:
+ *   the length of value, > 0 on success, -ERRNO errno code if error.
+ *
+ ****************************************************************************/
+
+ssize_t kvdb_get(struct kvdb* kvdb, const char* key, size_t key_len,
+    void* value, size_t val_len)
+{
+    ssize_t ret = kvdb_get_index(key);
+    switch (ret) {
+    case KVDB_PERSIST:
+        ret = kvdb_persist_get(kvdb, key, key_len, value, val_len);
+        break;
+#ifdef CONFIG_KVDB_TEMPORARY_STORAGE
+    case KVDB_MEM:
+        ret = kvdb_file_get(CONFIG_KVDB_TEMPORARY_PATH, key, value, val_len);
+        break;
+#endif
+    default:
+        ret = -EINVAL;
+        break;
+    }
+    return ret;
+}
+
+/****************************************************************************
+ * Name: kvdb_delete
+ *
+ * Description:
+ *   key-value delete.
+ *
+ * Input Parameters:
+ *   kvdb    - Pointer to save filekv instance.
+ *   key     - Pointer to key to delete.
+ *   key_len - the length of the key
+ *
+ * Returned Value:
+ *   0 on success, -ERRNO errno code if error.
+ *
+ ****************************************************************************/
+
+int kvdb_delete(struct kvdb* kvdb, const char* key, size_t key_len)
+{
+    int ret;
+
+    if (kvdb_is_readonly(key))
+        return -EPERM;
+
+    ret = kvdb_get_index(key);
+    switch (ret) {
+    case KVDB_PERSIST:
+        ret = kvdb_persist_delete(kvdb, key, key_len);
+        break;
+#ifdef CONFIG_KVDB_TEMPORARY_STORAGE
+    case KVDB_MEM:
+        ret = kvdb_file_delete(CONFIG_KVDB_TEMPORARY_PATH, key);
+        break;
+#endif
+    default:
+        ret = -EINVAL;
+        break;
+    }
+
+    return ret;
+}
+
+/****************************************************************************
+ * Name: kvdb_list
+ *
+ *   key-value list.
+ *
+ * Input Parameters:
+ *   kvdb      - Pointer to save filekv instance.
+ *   consume   - callback when key-value fetch success.
+ *   cookie    - private data for consume callback.
+ *
+ * Returned Value:
+ *   0 on success, -ERRNO errno code if error.
+ *
+ ****************************************************************************/
+
+int kvdb_list(struct kvdb* kvdb, kvdb_consume consume, void* cookie)
+{
+    int ret = kvdb_persist_list(kvdb, consume, cookie);
+    if (ret < 0)
+        return ret;
+
+#ifdef CONFIG_KVDB_TEMPORARY_STORAGE
+    ret = kvdb_file_list(CONFIG_KVDB_TEMPORARY_PATH, consume, cookie);
+#endif
+    return ret;
+}
+
+/****************************************************************************
+ * Name: kvdb_commit
+ *
+ *   key-value commit.
+ *
+ * Input Parameters:
+ *   kvdb      - Pointer to save filekv instance.
+ *
+ * Returned Value:
+ *   0 on success, -ERRNO errno code if error.
+ *
+ ****************************************************************************/
+
+int kvdb_commit(struct kvdb* kvdb)
+{
+    /* Filekv over tmpfs always no need for commit */
+
+    return kvdb_persist_commit(kvdb);
+}

--- a/kvdb/common.c
+++ b/kvdb/common.c
@@ -70,23 +70,6 @@ static inline int ascii2nibble(char ascii)
 }
 
 /****************************************************************************
- * Public Functions
- ****************************************************************************/
-
-int kvdb_get_index(const char* key)
-{
-    if (strncmp(key, PERSIST_LABEL, PERSIST_LABEL_LEN) == 0) {
-        return KVDB_PERSIST;
-    } else {
-#ifdef CONFIG_KVDB_TEMPORARY_STORAGE
-        return KVDB_MEM;
-#else
-        return -EINVAL;
-#endif
-    }
-}
-
-/****************************************************************************
  * Name: property_set_
  *
  * Description:
@@ -117,6 +100,10 @@ static int property_set_(const char* key, const char* value, bool oneway)
 
     return property_set_binary(key, value, strlen(value) + 1, oneway);
 }
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
 
 /****************************************************************************
  * Name: property_set

--- a/kvdb/file.c
+++ b/kvdb/file.c
@@ -39,19 +39,20 @@ static void kvdb_file_genpath(const char* path, const char* key, char* filepath)
 }
 
 /****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
  * kvdb_file_set
  ****************************************************************************/
 
-static int kvdb_file_set(const char* path, const char* key, const void* value, size_t val_len)
+int kvdb_file_set(const char* path, const char* key,
+    const void* value, size_t val_len)
 {
     char filepath[PATH_MAX];
     size_t nbyteswrite = 0;
     ssize_t result;
     int fd;
-
-    if (val_len >= PROP_VALUE_MAX) {
-        return -E2BIG;
-    }
 
     kvdb_file_genpath(path, key, filepath);
     fd = open(filepath, O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, 0666);
@@ -83,14 +84,27 @@ static int kvdb_file_set(const char* path, const char* key, const void* value, s
  * kvdb_file_get
  ****************************************************************************/
 
-static ssize_t kvdb_file_get(const char* path, const char* key, void* value, size_t val_len)
+ssize_t kvdb_file_get(const char* path, const char* key,
+    void* value, size_t val_len)
 {
     char filepath[PATH_MAX];
     size_t nbytesread = 0;
     ssize_t result;
+    ssize_t ret;
     int fd;
 
     kvdb_file_genpath(path, key, filepath);
+
+    if (value == NULL) {
+
+        /* Readonly property only check if exist, no read required. */
+
+        if (access(filepath, O_RDONLY) == 0)
+            return val_len;
+        else
+            return -ENOENT;
+    }
+
     fd = open(filepath, O_RDONLY | O_CLOEXEC, 0666);
     if (fd < 0) {
         KVERR("open %s error with %d", filepath, errno);
@@ -100,32 +114,35 @@ static ssize_t kvdb_file_get(const char* path, const char* key, void* value, siz
     do {
         result = read(fd, value + nbytesread, val_len - nbytesread);
         if (result < 0) {
+            result = -errno;
             if (result == -EINTR) {
                 continue;
             }
 
             KVERR("read %s error with %d", filepath, errno);
+            ret = -errno;
             close(fd);
-            return -errno;
+            return ret;
         }
 
         nbytesread += result;
     } while (result > 0 && nbytesread < val_len);
 
+    ret = nbytesread;
     close(fd);
-    return nbytesread;
+    return ret;
 }
 
 /****************************************************************************
  * kvdb_file_list
  ****************************************************************************/
 
-static int kvdb_file_list(const char* path, kvdb_consume consume, void* cookie)
+int kvdb_file_list(const char* path, kvdb_consume consume, void* cookie)
 {
     char value[PROP_VALUE_MAX];
     struct dirent* entry;
+    int ret = 0;
     DIR* dir;
-    int ret;
 
     dir = opendir(path);
     if (!dir) {
@@ -140,22 +157,23 @@ static int kvdb_file_list(const char* path, kvdb_consume consume, void* cookie)
 
         ret = kvdb_file_get(path, entry->d_name, value, PROP_VALUE_MAX);
         if (ret < 0) {
-            closedir(dir);
-            return ret;
+            ret = -errno;
+            break;
         }
 
         consume(entry->d_name, value, ret, cookie);
+        ret = 0;
     }
 
     closedir(dir);
-    return 0;
+    return ret;
 }
 
 /****************************************************************************
  * kvdb_file_delete
  ****************************************************************************/
 
-static int kvdb_file_delete(const char* path, const char* key)
+int kvdb_file_delete(const char* path, const char* key)
 {
     char filepath[PATH_MAX];
 
@@ -163,12 +181,9 @@ static int kvdb_file_delete(const char* path, const char* key)
     return unlink(filepath);
 }
 
+#ifdef CONFIG_KVDB_FILE
 /****************************************************************************
- * Public Functions
- ****************************************************************************/
-
-/****************************************************************************
- * Name: kvdb_init
+ * Name: kvdb_persist_init
  *
  * Description:
  *   init resource of nvs .
@@ -181,13 +196,13 @@ static int kvdb_file_delete(const char* path, const char* key)
  *
  ****************************************************************************/
 
-int kvdb_init(struct kvdb** kvdb)
+int kvdb_persist_init(struct kvdb** kvdb)
 {
     return 0;
 }
 
 /****************************************************************************
- * Name: kvdb_uninit
+ * Name: kvdb_persist_uninit
  *
  * Description:
  *   init resource of filekv .
@@ -200,12 +215,12 @@ int kvdb_init(struct kvdb** kvdb)
  *
  ****************************************************************************/
 
-void kvdb_uninit(struct kvdb* kvdb)
+void kvdb_persist_uninit(struct kvdb* kvdb)
 {
 }
 
 /****************************************************************************
- * Name: kvdb_set
+ * Name: kvdb_persist_set
  *
  * Description:
  *   key-value set.
@@ -223,28 +238,14 @@ void kvdb_uninit(struct kvdb* kvdb)
  *
  ****************************************************************************/
 
-int kvdb_set(struct kvdb* kvdb, const char* key, size_t key_len,
+int kvdb_persist_set(struct kvdb* kvdb, const char* key, size_t key_len,
     const void* value, size_t val_len, bool force)
 {
-    int ret;
-
-    if (key == NULL || value == NULL)
-        return -EINVAL;
-
-    ret = kvdb_get_index(key);
-    if (ret < 0)
-        return ret;
-
-#ifdef CONFIG_KVDB_TEMPORARY_PATH
-    if (ret == KVDB_MEM) {
-        return kvdb_file_set(CONFIG_KVDB_TEMPORARY_PATH, key, value, val_len);
-    }
-#endif
     return kvdb_file_set(CONFIG_KVDB_PERSIST_PATH, key, value, val_len);
 }
 
 /****************************************************************************
- * Name: kvdb_get
+ * Name: kvdb_persist_get
  *
  * Description:
  *   key-value get.
@@ -261,28 +262,14 @@ int kvdb_set(struct kvdb* kvdb, const char* key, size_t key_len,
  *
  ****************************************************************************/
 
-ssize_t kvdb_get(struct kvdb* kvdb, const char* key, size_t key_len, void* value, size_t val_len)
+ssize_t kvdb_persist_get(struct kvdb* kvdb, const char* key, size_t key_len,
+    void* value, size_t val_len)
 {
-    int ret;
-
-    if (key == NULL || value == NULL)
-        return -EINVAL;
-
-    ret = kvdb_get_index(key);
-    if (ret < 0) {
-        return ret;
-    }
-
-#ifdef CONFIG_KVDB_TEMPORARY_PATH
-    if (ret == KVDB_MEM) {
-        return kvdb_file_get(CONFIG_KVDB_TEMPORARY_PATH, key, value, val_len);
-    }
-#endif
     return kvdb_file_get(CONFIG_KVDB_PERSIST_PATH, key, value, val_len);
 }
 
 /****************************************************************************
- * Name: kvdb_delete
+ * Name: kvdb_persist_delete
  *
  * Description:
  *   key-value delete.
@@ -297,46 +284,13 @@ ssize_t kvdb_get(struct kvdb* kvdb, const char* key, size_t key_len, void* value
  *
  ****************************************************************************/
 
-int kvdb_delete(struct kvdb* kvdb, const char* key, size_t key_len)
+int kvdb_persist_delete(struct kvdb* kvdb, const char* key, size_t key_len)
 {
-    int ret;
-
-    if (key == NULL)
-        return -EINVAL;
-
-    ret = kvdb_get_index(key);
-    if (ret < 0)
-        return ret;
-
-#ifdef CONFIG_KVDB_TEMPORARY_PATH
-    if (ret == KVDB_MEM) {
-        return kvdb_file_delete(CONFIG_KVDB_TEMPORARY_PATH, key);
-    }
-#endif
     return kvdb_file_delete(CONFIG_KVDB_PERSIST_PATH, key);
 }
 
 /****************************************************************************
- * Name: kvdb_commit
- *
- * Description:
- *   key-value commit, unused
- *
- * Input Parameters:
- *   kvdb    - Pointer to save filekv instance.
- *
- * Returned Value:
- *   0 on success, -ERRNO errno code if error.
- *
- ****************************************************************************/
-
-int kvdb_commit(struct kvdb* kvdb)
-{
-    return 0;
-}
-
-/****************************************************************************
- * Name: kvdb_list
+ * Name: kvdb_persist_list
  *
  *   key-value list.
  *
@@ -350,20 +304,26 @@ int kvdb_commit(struct kvdb* kvdb)
  *
  ****************************************************************************/
 
-int kvdb_list(struct kvdb* kvdb, kvdb_consume consume, void* cookie)
+int kvdb_persist_list(struct kvdb* kvdb, kvdb_consume consume, void* cookie)
 {
-    int ret;
-
-    if (!consume)
-        return -EINVAL;
-
-    ret = kvdb_file_list(CONFIG_KVDB_PERSIST_PATH, consume, cookie);
-    if (ret < 0)
-        return ret;
-
-#ifdef CONFIG_KVDB_TEMPORARY_PATH
-    return kvdb_file_list(CONFIG_KVDB_TEMPORARY_PATH, consume, cookie);
-#else
-    return ret;
-#endif
+    return kvdb_file_list(CONFIG_KVDB_PERSIST_PATH, consume, cookie);
 }
+
+/****************************************************************************
+ * Name: kvdb_persist_commit
+ *
+ *   key-value commit.
+ *
+ * Input Parameters:
+ *   kvdb      - Pointer to save filekv instance.
+ *
+ * Returned Value:
+ *   0 on success, -ERRNO errno code if error.
+ *
+ ****************************************************************************/
+
+int kvdb_persist_commit(struct kvdb* kvdb)
+{
+    return 0;
+}
+#endif

--- a/kvdb/internal.h
+++ b/kvdb/internal.h
@@ -59,7 +59,6 @@ enum {
 #ifdef CONFIG_KVDB_TEMPORARY_STORAGE
     KVDB_MEM, /* save key-value pairs in memory */
 #endif
-    KVDB_COUNT
 };
 
 struct kvdb;
@@ -74,7 +73,20 @@ int kvdb_commit(struct kvdb* kvdb);
 int kvdb_init(struct kvdb** kvdb);
 void kvdb_uninit(struct kvdb* kvdb);
 
-int kvdb_get_index(const char* key);
+int kvdb_persist_init(struct kvdb** kvdb);
+void kvdb_persist_uninit(struct kvdb* kvdb);
+int kvdb_persist_commit(struct kvdb* kvdb);
+int kvdb_persist_list(struct kvdb* kvdb, kvdb_consume consume, void* cookie);
+ssize_t kvdb_persist_get(struct kvdb* kvdb, const char* key, size_t key_len, void* value, size_t val_len);
+int kvdb_persist_set(struct kvdb* kvdb, const char* key, size_t key_len, const void* value, size_t val_len, bool force);
+int kvdb_persist_delete(struct kvdb* kvdb, const char* key, size_t key_len);
+
+#ifdef CONFIG_KVDB_TEMPORARY_STORAGE
+int kvdb_file_set(const char* path, const char* key, const void* value, size_t val_len);
+ssize_t kvdb_file_get(const char* path, const char* key, void* value, size_t val_len);
+int kvdb_file_list(const char* path, kvdb_consume consume, void* cookie);
+int kvdb_file_delete(const char* path, const char* key);
+#endif
 
 #if defined(__cplusplus)
 }

--- a/kvdb/nvs.c
+++ b/kvdb/nvs.c
@@ -34,27 +34,22 @@
  ****************************************************************************/
 
 struct kvdb {
-    int fd[KVDB_COUNT];
+    int fd;
 };
 
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
 
-static const char* kvdb_skip_prefix(const char* key, int index)
+static inline const char* kvdb_skip_prefix(const char* key)
 {
-    return index == KVDB_PERSIST ? key + PERSIST_LABEL_LEN : key;
+    return key + PERSIST_LABEL_LEN;
 }
 
-static void kvdb_add_prefix(char* out, size_t outlen,
-    int index, const char* in)
+static void kvdb_add_prefix(char* out, size_t outlen, const char* in)
 {
-    if (index == KVDB_PERSIST) {
-        strlcpy(out, PERSIST_LABEL, outlen);
-        strlcat(out, in, outlen);
-    } else {
-        strlcpy(out, in, outlen);
-    }
+    strlcpy(out, PERSIST_LABEL, outlen);
+    strlcat(out, in, outlen);
 }
 
 /****************************************************************************
@@ -62,7 +57,7 @@ static void kvdb_add_prefix(char* out, size_t outlen,
  ****************************************************************************/
 
 /****************************************************************************
- * Name: kvdb_init
+ * Name: kvdb_persist_init
  *
  * Description:
  *   init resource of nvs .
@@ -75,7 +70,7 @@ static void kvdb_add_prefix(char* out, size_t outlen,
  *
  ****************************************************************************/
 
-int kvdb_init(struct kvdb** kvdb)
+int kvdb_persist_init(struct kvdb** kvdb)
 {
     struct kvdb* handle;
     int ret;
@@ -89,40 +84,21 @@ int kvdb_init(struct kvdb** kvdb)
     ret = open(CONFIG_KVDB_PERSIST_PATH, O_RDWR | O_CLOEXEC);
     if (ret < 0) {
         ret = -errno;
-        KVERR("open %s error with %d",
-            CONFIG_KVDB_PERSIST_PATH, ret);
+        KVERR("open %s error with %d", CONFIG_KVDB_PERSIST_PATH, ret);
         goto err;
     }
 
-    handle->fd[KVDB_PERSIST] = ret;
-
-#ifdef CONFIG_KVDB_TEMPORARY_STORAGE
-    ret = open(CONFIG_KVDB_TEMPORARY_PATH, O_RDWR | O_CLOEXEC);
-    if (ret < 0) {
-        ret = -errno;
-        KVERR("open %s error with %d",
-            CONFIG_KVDB_TEMPORARY_PATH, ret);
-        goto err;
-    }
-
-    handle->fd[KVDB_MEM] = ret;
-#endif
+    handle->fd = ret;
     *kvdb = handle;
-
     return 0;
 
 err:
-    for (int i = 0; i < KVDB_COUNT; i++) {
-        if (handle->fd[i])
-            close(handle->fd[i]);
-    }
-
     free(handle);
     return ret;
 }
 
 /****************************************************************************
- * Name: kvdb_uninit
+ * Name: kvdb_persist_uninit
  *
  * Description:
  *   init resource of nvs .
@@ -135,19 +111,14 @@ err:
  *
  ****************************************************************************/
 
-void kvdb_uninit(struct kvdb* kvdb)
+void kvdb_persist_uninit(struct kvdb* kvdb)
 {
-    int i;
-
-    for (i = 0; i < KVDB_COUNT; i++) {
-        close(kvdb->fd[i]);
-    }
-
+    close(kvdb->fd);
     free(kvdb);
 }
 
 /****************************************************************************
- * Name: kvdb_set
+ * Name: kvdb_persist_set
  *
  * Description:
  *   key-value set.
@@ -165,21 +136,13 @@ void kvdb_uninit(struct kvdb* kvdb)
  *
  ****************************************************************************/
 
-int kvdb_set(struct kvdb* kvdb, const char* key, size_t key_len,
+int kvdb_persist_set(struct kvdb* kvdb, const char* key, size_t key_len,
     const void* value, size_t val_len, bool force)
 {
     struct config_data_s data;
-    int index;
     int ret;
 
-    if (key == NULL || key_len == 0)
-        return -EINVAL;
-
-    index = kvdb_get_index(key);
-    if (index < 0)
-        return index;
-
-    key = kvdb_skip_prefix(key, index);
+    key = kvdb_skip_prefix(key);
 
     if (strlen(key) >= sizeof(data.name))
         return -EINVAL;
@@ -189,7 +152,7 @@ int kvdb_set(struct kvdb* kvdb, const char* key, size_t key_len,
     data.len = val_len;
     data.configdata = (uint8_t*)value;
 
-    ret = ioctl(kvdb->fd[index], CFGDIOC_SETCONFIG, &data);
+    ret = ioctl(kvdb->fd, CFGDIOC_SETCONFIG, &data);
     if (ret < 0) {
         ret = -errno;
         KVERR("IOCTL_SETCONFIG ERROR %d", ret);
@@ -199,7 +162,7 @@ int kvdb_set(struct kvdb* kvdb, const char* key, size_t key_len,
 }
 
 /****************************************************************************
- * Name: kvdb_get
+ * Name: kvdb_persist_get
  *
  * Description:
  *   key-value get.
@@ -216,20 +179,15 @@ int kvdb_set(struct kvdb* kvdb, const char* key, size_t key_len,
  *
  ****************************************************************************/
 
-ssize_t kvdb_get(struct kvdb* kvdb, const char* key, size_t key_len, void* value, size_t val_len)
+ssize_t kvdb_persist_get(struct kvdb* kvdb, const char* key, size_t key_len, void* value, size_t val_len)
 {
     struct config_data_s data;
-    int index;
     int ret;
 
     if (key == NULL || key_len == 0)
         return -EINVAL;
 
-    index = kvdb_get_index(key);
-    if (index < 0)
-        return index;
-
-    key = kvdb_skip_prefix(key, index);
+    key = kvdb_skip_prefix(key);
 
     if (strlen(key) >= sizeof(data.name))
         return -EINVAL;
@@ -238,7 +196,7 @@ ssize_t kvdb_get(struct kvdb* kvdb, const char* key, size_t key_len, void* value
     data.configdata = (uint8_t*)value;
     data.len = val_len;
 
-    ret = ioctl(kvdb->fd[index], CFGDIOC_GETCONFIG, &data);
+    ret = ioctl(kvdb->fd, CFGDIOC_GETCONFIG, &data);
     if (ret < 0) {
         ret = -errno;
         KVERR("CFGDIOC_GETCONFIG ERROR: %d", ret);
@@ -249,7 +207,7 @@ ssize_t kvdb_get(struct kvdb* kvdb, const char* key, size_t key_len, void* value
 }
 
 /****************************************************************************
- * Name: kvdb_delete
+ * Name: kvdb_persist_delete
  *
  * Description:
  *   key-value delete.
@@ -264,27 +222,19 @@ ssize_t kvdb_get(struct kvdb* kvdb, const char* key, size_t key_len, void* value
  *
  ****************************************************************************/
 
-int kvdb_delete(struct kvdb* kvdb, const char* key, size_t key_len)
+int kvdb_persist_delete(struct kvdb* kvdb, const char* key, size_t key_len)
 {
     struct config_data_s data;
-    int index;
     int ret;
 
-    if (key == NULL || key_len == 0)
-        return -EINVAL;
-
-    index = kvdb_get_index(key);
-    if (index < 0)
-        return index;
-
-    key = kvdb_skip_prefix(key, index);
+    key = kvdb_skip_prefix(key);
 
     if (strlen(key) >= sizeof(data.name))
         return -EINVAL;
 
     strlcpy(data.name, key, sizeof(data.name));
 
-    ret = ioctl(kvdb->fd[index], CFGDIOC_DELCONFIG, &data);
+    ret = ioctl(kvdb->fd, CFGDIOC_DELCONFIG, &data);
     if (ret < 0) {
         ret = -errno;
         KVERR("CFGDIOC_DELCONFIG ERROR: %d", ret);
@@ -294,7 +244,7 @@ int kvdb_delete(struct kvdb* kvdb, const char* key, size_t key_len)
 }
 
 /****************************************************************************
- * Name: kvdb_list
+ * Name: kvdb_persist_list
  *
  * Description:
  *   key-value list.
@@ -309,58 +259,63 @@ int kvdb_delete(struct kvdb* kvdb, const char* key, size_t key_len)
  *
  ****************************************************************************/
 
-int kvdb_list(struct kvdb* kvdb, kvdb_consume consume, void* cookie)
+int kvdb_persist_list(struct kvdb* kvdb, kvdb_consume consume, void* cookie)
 {
     char key[CONFIG_NAME_MAX + PERSIST_LABEL_LEN];
     uint8_t buf[PROP_VALUE_MAX];
     struct config_data_s data;
-    int i;
+    int ret;
 
     if (!consume)
         return 0;
 
-    for (i = 0; i < KVDB_COUNT; i++) {
+    data.configdata = buf;
+    data.len = PROP_VALUE_MAX;
+    ret = ioctl(kvdb->fd, CFGDIOC_FIRSTCONFIG, &data);
+    if (ret < 0)
+        return ret;
+
+    kvdb_add_prefix(key, sizeof(key), data.name);
+
+    consume(key, data.configdata, data.len, cookie);
+
+    while (1) {
         data.configdata = buf;
         data.len = PROP_VALUE_MAX;
-        int ret = ioctl(kvdb->fd[i], CFGDIOC_FIRSTCONFIG, &data);
-        if (ret < 0)
-            continue;
+        ret = ioctl(kvdb->fd, CFGDIOC_NEXTCONFIG, &data);
+        if (ret < 0) {
+            ret = -errno;
 
-        kvdb_add_prefix(key, sizeof(key), i, data.name);
+            /* ENOENT is expected when there are no more entries */
+
+            if (ret == -ENOENT)
+                ret = 0;
+
+            break;
+        }
+
+        kvdb_add_prefix(key, sizeof(key), data.name);
 
         consume(key, data.configdata, data.len, cookie);
-
-        while (1) {
-            data.configdata = buf;
-            data.len = PROP_VALUE_MAX;
-            ret = ioctl(kvdb->fd[i], CFGDIOC_NEXTCONFIG, &data);
-            if (ret < 0)
-                break;
-
-            kvdb_add_prefix(key, sizeof(key), i, data.name);
-
-            consume(key, data.configdata, data.len, cookie);
-        }
     }
 
-    return 0;
+    return ret;
 }
 
 /****************************************************************************
- * Name: kvdb_commit
+ * Name: kvdb_persist_commit
  *
- * Description:
- *   key-value commit, unused
+ *   key-value commit.
  *
  * Input Parameters:
- *   kvdb    - Pointer to save nvs kvdb instance.
+ *   kvdb      - Pointer to save filekv instance.
  *
  * Returned Value:
  *   0 on success, -ERRNO errno code if error.
  *
  ****************************************************************************/
 
-int kvdb_commit(struct kvdb* kvdb)
+int kvdb_persist_commit(struct kvdb* kvdb)
 {
     return 0;
 }

--- a/kvdb/unqlite.c
+++ b/kvdb/unqlite.c
@@ -31,62 +31,22 @@ typedef struct kvdb_consume_data {
 } kvdb_consume_data;
 
 struct kvdb {
-    unqlite* db[KVDB_COUNT];
+    unqlite* db;
 };
 
 /****************************************************************************
  * Database Functions
  ****************************************************************************/
 
-static bool kvdb_is_readonly(const char* key)
+int kvdb_persist_set(struct kvdb* kvdb, const char* key, size_t key_len, const void* value, size_t val_len, bool force)
 {
-    return strncmp(key, "ro.", 3) == 0;
+    return unqlite_kv_store(kvdb->db, key, key_len, value, val_len);
 }
 
-static bool unqlite_kv_is_exist(unqlite* db, const char* key, size_t key_len)
+ssize_t kvdb_persist_get(struct kvdb* kvdb, const char* key, size_t key_len, void* value, size_t val_len)
 {
-    unqlite_int64 value_len;
-
-    return unqlite_kv_fetch(db, key, key_len, NULL, &value_len) >= 0;
-}
-
-int kvdb_set(struct kvdb* kvdb, const char* key, size_t key_len, const void* value, size_t val_len, bool force)
-{
-    if (--key_len >= PROP_NAME_MAX)
-        return -E2BIG;
-
-    if (!key || key[key_len])
-        return -EINVAL;
-
-    if (val_len >= PROP_VALUE_MAX)
-        return -E2BIG;
-
-    /* no, then try database  */
-    int i = kvdb_get_index(key);
-    if (i < 0)
-        return i;
-
-    if (!force && kvdb_is_readonly(key) && unqlite_kv_is_exist(kvdb->db[i], key, key_len + 1))
-        return -EPERM;
-
-    return unqlite_kv_store(kvdb->db[i], key, ++key_len, value, val_len);
-}
-
-ssize_t kvdb_get(struct kvdb* kvdb, const char* key, size_t key_len, void* value, size_t val_len)
-{
-    if (--key_len >= PROP_NAME_MAX)
-        return -E2BIG;
-
-    if (key[key_len])
-        return -EINVAL;
-
-    /* no, then try database  */
-    int i = kvdb_get_index(key);
-    if (i < 0)
-        return i;
-
     unqlite_int64 val_size = val_len;
-    int ret = unqlite_kv_fetch(kvdb->db[i], key, ++key_len, value, &val_size);
+    ssize_t ret = unqlite_kv_fetch(kvdb->db, key, key_len, value, &val_size);
     if (ret < 0)
         return ret;
 
@@ -96,23 +56,9 @@ ssize_t kvdb_get(struct kvdb* kvdb, const char* key, size_t key_len, void* value
     return val_size;
 }
 
-int kvdb_delete(struct kvdb* kvdb, const char* key, size_t key_len)
+int kvdb_persist_delete(struct kvdb* kvdb, const char* key, size_t key_len)
 {
-    if (--key_len >= PROP_NAME_MAX)
-        return -E2BIG;
-
-    if (key[key_len])
-        return -EINVAL;
-
-    if (kvdb_is_readonly(key))
-        return -EPERM;
-
-    /* no, then try database  */
-    int i = kvdb_get_index(key);
-    if (i < 0)
-        return i;
-
-    return unqlite_kv_delete(kvdb->db[i], key, ++key_len);
+    return unqlite_kv_delete(kvdb->db, key, key_len);
 }
 
 static int kvdb_list_value(const void* value, unsigned int len, void* arg)
@@ -130,96 +76,63 @@ static int kvdb_list_key(const void* value, unsigned int len, void* arg)
     return unqlite_kv_cursor_data_callback(data->cur, kvdb_list_value, data);
 }
 
-int kvdb_list(struct kvdb* kvdb, kvdb_consume consume, void* cookie)
+int kvdb_persist_list(struct kvdb* kvdb, kvdb_consume consume, void* cookie)
 {
-    for (int i = 0; i < KVDB_COUNT; i++) {
-        unqlite_kv_cursor* cur = NULL;
-        unqlite_kv_cursor_init(kvdb->db[i], &cur);
+    unqlite_kv_cursor* cur = NULL;
+    unqlite_kv_cursor_init(kvdb->db, &cur);
 
-        kvdb_consume_data data = {
-            .consume = consume,
-            .cookie = cookie,
-            .cur = cur,
-        };
+    kvdb_consume_data data = {
+        .consume = consume,
+        .cookie = cookie,
+        .cur = cur,
+    };
 
-        unqlite_kv_cursor_first_entry(cur);
-        while (unqlite_kv_cursor_valid_entry(cur)) {
-            int ret = unqlite_kv_cursor_key_callback(cur, kvdb_list_key, &data);
-            if (ret < 0) { /* exit loop demanded by consume */
-                unqlite_kv_cursor_release(kvdb->db[i], cur);
-                return ret;
-            }
-            unqlite_kv_cursor_next_entry(cur);
+    unqlite_kv_cursor_first_entry(cur);
+    while (unqlite_kv_cursor_valid_entry(cur)) {
+        int ret = unqlite_kv_cursor_key_callback(cur, kvdb_list_key, &data);
+        if (ret < 0) { /* exit loop demanded by consume */
+            unqlite_kv_cursor_release(kvdb->db, cur);
+            return ret;
         }
-        unqlite_kv_cursor_release(kvdb->db[i], cur);
+        unqlite_kv_cursor_next_entry(cur);
     }
+    unqlite_kv_cursor_release(kvdb->db, cur);
 
     return 0;
 }
 
-int kvdb_commit(struct kvdb* kvdb)
+int kvdb_persist_commit(struct kvdb* kvdb)
 {
-    int ret = 0;
-
-    for (int i = 0; i < KVDB_COUNT; i++) {
-        int r = unqlite_commit(kvdb->db[i]);
-        if (r < 0) {
-            KVERR("commit db:%d error %d!\n", i, r);
-            if (ret == 0) {
-                ret = r;
-            }
-        }
+    int ret = unqlite_commit(kvdb->db);
+    if (ret < 0) {
+        KVERR("commit db:%p error %d!\n", kvdb->db, ret);
     }
 
     return ret;
 }
 
-void kvdb_uninit(struct kvdb* kvdb)
+void kvdb_persist_uninit(struct kvdb* kvdb)
 {
     if (kvdb != NULL) {
-        for (int i = 0; i < KVDB_COUNT; i++) {
-            if (kvdb->db[i]) {
-                unqlite_close(kvdb->db[i]);
-                kvdb->db[i] = NULL;
-            }
-        }
-
+        unqlite_close(kvdb->db);
         free(kvdb);
-        kvdb = NULL;
     }
 }
 
-int kvdb_init(struct kvdb** kvdb)
+int kvdb_persist_init(struct kvdb** kvdb)
 {
-    static const char* path[KVDB_COUNT] = {
-        [KVDB_PERSIST] = CONFIG_KVDB_PERSIST_PATH,
-#ifdef CONFIG_KVDB_TEMPORARY_STORAGE
-        [KVDB_MEM] = CONFIG_KVDB_TEMPORARY_PATH,
-#endif
-    };
+    int ret;
 
-    int ret = 0;
-
-    *kvdb = calloc(1, sizeof(struct kvdb));
+    *kvdb = zalloc(sizeof(struct kvdb));
     if (*kvdb == NULL)
         return -ENOMEM;
 
     /* open database */
-    for (int i = 0; i < KVDB_COUNT; i++) {
-        if (path[i][0])
-            ret = unqlite_open(&(*kvdb)->db[i], path[i], UNQLITE_OPEN_CREATE | UNQLITE_OPEN_OMIT_JOURNALING);
-#ifdef CONFIG_KVDB_TEMPORARY_STORAGE
-        else
-            ret = unqlite_open(&(*kvdb)->db[i], NULL, UNQLITE_OPEN_IN_MEMORY);
-#endif
 
-        if (ret < 0)
-            goto out;
-    }
+    ret = unqlite_open(&(*kvdb)->db, CONFIG_KVDB_PERSIST_PATH, UNQLITE_OPEN_CREATE | UNQLITE_OPEN_OMIT_JOURNALING);
 
-    return ret;
+    if (ret < 0)
+        free(*kvdb);
 
-out:
-    kvdb_uninit(*kvdb);
     return ret;
 }


### PR DESCRIPTION
## Summary
Persist NVS KVDB and rammtd temporary is not a good case,
Unqlite over tmpfs is much slower than tmpfs.

## Impact
Now we always use tmpfs as a temporary kvdb backend.

## Testing
CI-test

