### PR TITLE
fs/kvdb:extend val_len to 2 bytes to support property value up to 1024

### DIFF
--- a/include/kvdb.h
+++ b/include/kvdb.h
@@ -20,7 +20,7 @@
 #include <cutils/properties.h>
 #include <sys/types.h>
 
-#define PROP_MSG_MAX (3 + PROP_NAME_MAX + PROP_VALUE_MAX) /* +3 = +1(opcode) +2(len) */
+#define PROP_MSG_MAX (4 + PROP_NAME_MAX + PROP_VALUE_MAX) /* +4 = +1(opcode) +1(key_len) +2(val_len) */
 
 #if defined(__cplusplus)
 extern "C" {

--- a/include/sys/system_properties.h
+++ b/include/sys/system_properties.h
@@ -39,7 +39,7 @@ extern "C" {
 
 typedef struct prop_info prop_info;
 
-#define PROP_VALUE_MAX  255
+#define PROP_VALUE_MAX  1024
 
 /*
  * Sets system property `name` to `value`, creating it if it doesn't exist.

--- a/kvdb/client.c
+++ b/kvdb/client.c
@@ -230,18 +230,18 @@ again:
         return fd;
     }
 
-    /*-------------------------------------*
-     | 1 |   1   |   1   | key_len |val_len|
-     |-------------------------------------|
-     |'S'|key_len|val_len|[key'\0']|[value]|
-     *-------------------------------------*/
+    /*---------------------------------------------*
+     | 1 |   1   |     2     | key_len |  val_len  |
+     |---------------------------------------------|
+     |'S'|key_len|val_len(LE)|[key'\0']|  [value]  |
+     *---------------------------------------------*/
 
-    char cmd[3] = {
-        'S', key_len, val_len
+    char cmd[4] = {
+        'S', key_len, val_len & 0xff, (val_len >> 8) & 0xff
     };
 
     struct iovec iov[3] = {
-        { .iov_base = cmd, .iov_len = 3 },
+        { .iov_base = cmd, .iov_len = 4 },
         { .iov_base = (char*)key, .iov_len = key_len },
         { .iov_base = (char*)value, .iov_len = val_len },
     };
@@ -321,18 +321,18 @@ ssize_t property_get_binary(const char* key, void* value, size_t val_len)
         return fd;
     }
 
-    /*-----------------------------*
-     | 1 |   1   | key_len |val_len|
-     | --------------------|-------|
-     |'G'|key_len|[key'\0']|[value]|
-     *-----------------------------*/
+    /*-----------------------------------------*
+     | 1 |   1   |     2     | key_len |val_len|
+     | ----------------------------------------|
+     |'G'|key_len|val_len(LE)|[key'\0']|[value]|
+     *-----------------------------------------*/
 
-    char cmd[3] = {
-        'G', key_len, val_len
+    char cmd[4] = {
+        'G', key_len, val_len & 0xff, (val_len >> 8) & 0xff
     };
 
     struct iovec iov[2] = {
-        { .iov_base = cmd, .iov_len = 3 },
+        { .iov_base = cmd, .iov_len = 4 },
         { .iov_base = (char*)key, .iov_len = key_len },
     };
 
@@ -513,42 +513,42 @@ int property_list_binary(void (*propfn)(const char* key, const void* value, size
     }
 
     while (1) {
-        /*---------------------------------*
-         |   1   |   1   | key_len |val_len|
-         |---------------------------------|
-         |key_len|val_len|[key'\0']|[value]|
-         *---------------------------------*/
+        /*-------------------------------------------*
+         |   1   |     2     | key_len |  val_len  |
+         |-------------------------------------------|
+         |key_len|val_len(LE)|[key'\0']|  [value]  |
+         *-------------------------------------------*/
 
-        ret = recv_safe(fd, msg, 0, 2);
+        ret = recv_safe(fd, msg, 0, 3);
         if (ret < 0) {
             ret = -errno;
             KVERR("recv_safe failed, ret=%d\n", ret);
             goto out;
         }
 
-        if (msg[0] == 0 && msg[1] == 0) {
+        size_t key_len = (unsigned char)msg[0];
+        if (key_len == 0) {
             /* end of list */
             ret = 0;
             break;
         }
 
-        size_t key_len = (unsigned char)msg[0];
         if (key_len > PROP_NAME_MAX)
             continue;
 
-        size_t val_len = (unsigned char)msg[1];
+        size_t val_len = (unsigned char)msg[1] | ((unsigned char)msg[2] << 8);
         if (val_len >= PROP_VALUE_MAX)
             continue;
 
-        size_t total = key_len + val_len + 2;
-        ret = recv_safe(fd, msg, 2, total);
+        size_t total = key_len + val_len + 3;
+        ret = recv_safe(fd, msg, 3, total);
         if (ret < 0) {
             KVERR("recv_safe failed, ret=%d\n", ret);
             break;
         }
 
-        const char* key = msg + 2;
-        void* value = msg + 2 + key_len;
+        const char* key = msg + 3;
+        void* value = msg + 3 + key_len;
         if (key[key_len - 1])
             continue;
 
@@ -718,8 +718,8 @@ ssize_t property_monitor_read(int fd, char* newkey, void* newvalue, size_t val_l
         return -ENOMEM;
     }
 
-    ssize_t ret = recv(fd, msg, 2, 0);
-    if (ret < 2) {
+    ssize_t ret = recv(fd, msg, 3, 0);
+    if (ret < 3) {
         KVERR("recv failed, ret=%d, errno=%d\n", ret, errno);
         free(msg);
         return ret < 0 ? -errno : -ENODATA;
@@ -731,13 +731,13 @@ ssize_t property_monitor_read(int fd, char* newkey, void* newvalue, size_t val_l
         return -E2BIG;
     }
 
-    size_t len = (unsigned char)msg[1];
+    size_t len = (unsigned char)msg[1] | ((unsigned char)msg[2] << 8);
     if (len > PROP_VALUE_MAX) {
         free(msg);
         return -E2BIG;
     }
 
-    size_t total = key_len + len + 2;
+    size_t total = key_len + len + 3;
     ret = recv_safe(fd, msg, ret, total);
     if (ret < 0) {
         KVERR("recv_safe failed, ret=%d\n", ret);
@@ -745,18 +745,18 @@ ssize_t property_monitor_read(int fd, char* newkey, void* newvalue, size_t val_l
         return ret;
     }
 
-    const char* key = &msg[2];
+    const char* key = &msg[3];
     if (newkey != NULL)
         strlcpy(newkey, key, PROP_NAME_MAX);
 
     if (newvalue != NULL) {
-        /*--------------------------------*
-         |   1   |   1   | key_len |val_len|
-         |---------------------------------|
-         |key_len|val_len|[key'\0']|[value]|
-         *---------------------------------*/
+        /*-------------------------------------------*
+         |   1   |     2     | key_len |  val_len  |
+         |-------------------------------------------|
+         |key_len|val_len(LE)|[key'\0']|  [value]  |
+         *-------------------------------------------*/
 
-        const void* value = &msg[2 + key_len];
+        const void* value = &msg[3 + key_len];
         len = val_len > len ? len : val_len;
         memcpy(newvalue, value, len);
     }

--- a/kvdb/server.c
+++ b/kvdb/server.c
@@ -114,21 +114,21 @@ static void kvdb_monitor_notify(kvdb_server* server, const char* key, const void
     size_t key_len = strlen(key) + 1;
 
     /* value != NULL
-      *---------------------------------*
-      |   1   |   1   | key_len |val_len|
-      |---------------------------------|
-      |key_len|val_len|[key'\0']|[value]|
-      *---------------------------------*
+      *-------------------------------------------*
+      |   1   |     2     | key_len |  val_len  |
+      |-------------------------------------------|
+      |key_len|val_len(LE)|[key'\0']|  [value]  |
+      *-------------------------------------------*
       * value == NULL
-      *-------------------------*
-      |   1   |   1   | key_len |
-      |-------------------------|
-      |key_len|   0   |[key'\0']|
-      *-------------------------*/
+      *-----------------------------*
+      |   1   |     2     | key_len |
+      |-----------------------------|
+      |key_len|     0     |[key'\0']|
+      *-----------------------------*/
 
-    char cmd[2] = { key_len, val_len };
+    char cmd[3] = { key_len, val_len & 0xff, (val_len >> 8) & 0xff };
     struct iovec iov[3] = {
-        { .iov_base = cmd, .iov_len = 2 },
+        { .iov_base = cmd, .iov_len = 3 },
         { .iov_base = (char*)key, .iov_len = key_len },
         { .iov_base = (char*)value, .iov_len = val_len },
     };
@@ -146,7 +146,7 @@ static void kvdb_monitor_notify(kvdb_server* server, const char* key, const void
 
         int space;
         ioctl(mon->fd, FIONSPACE, &space);
-        if (space < (key_len + val_len + 2)) {
+        if (space < (key_len + val_len + 3)) {
             /* Check space before monitor notify to avoid deadlock.
                Cause the send may write buffer full and wait,
                then the client just get a new key and also wait,
@@ -323,12 +323,12 @@ static void kvdb_unbind(int fd[])
 static void kvdb_list_consume(const char* key, const void* value, size_t val_len, void* cookie)
 {
     size_t key_len = strlen(key) + 1;
-    char cmd[2] = {
-        key_len, val_len
+    char cmd[3] = {
+        key_len, val_len & 0xff, (val_len >> 8) & 0xff
     };
 
     struct iovec iov[3] = {
-        { .iov_base = cmd, .iov_len = 2 },
+        { .iov_base = cmd, .iov_len = 3 },
         { .iov_base = (char*)key, .iov_len = key_len },
         { .iov_base = (char*)value, .iov_len = val_len },
     };
@@ -383,7 +383,7 @@ static bool kvdb_client(kvdb_server* server, int fd)
         goto out;
     }
 
-    msg[0] = msg[1] = msg[2] = 0; /* zero the first key bytes */
+    msg[0] = msg[1] = msg[2] = msg[3] = 0; /* zero the first header bytes */
 
     len = recv(fd, msg, PROP_MSG_MAX, 0);
     if (len <= 0) {
@@ -416,19 +416,21 @@ static bool kvdb_client(kvdb_server* server, int fd)
         break;
     }
     case 'G': {
-        if (len < 3)
-            len = kvdb_recv(fd, msg, len, 3);
+        if (len < 4)
+            len = kvdb_recv(fd, msg, len, 4);
         if (len < 0)
             goto out;
 
         size_t key_len = (unsigned char)msg[1];
-        size_t val_len = (unsigned char)msg[2];
-        size_t end_pos = key_len + 3;
+        size_t val_len = (unsigned char)msg[2] | ((unsigned char)msg[3] << 8);
+        size_t end_pos = key_len + 4;
         if (end_pos >= PROP_MSG_MAX)
             break;
 
-        const char* key = msg + 3;
+        const char* key = msg + 4;
         char value[PROP_VALUE_MAX];
+        if (val_len > PROP_VALUE_MAX)
+            val_len = PROP_VALUE_MAX;
         len = kvdb_recv(fd, msg, len, end_pos);
         if (len > 0) {
             len = kvdb_get(server->kvdb, key, key_len, value, val_len);
@@ -438,18 +440,18 @@ static bool kvdb_client(kvdb_server* server, int fd)
         break;
     }
     case 'S': {
-        if (len < 3)
-            len = kvdb_recv(fd, msg, len, 3);
+        if (len < 4)
+            len = kvdb_recv(fd, msg, len, 4);
         if (len < 0)
             goto out;
 
         size_t key_len = (unsigned char)msg[1];
-        size_t val_len = (unsigned char)msg[2];
-        size_t end_pos = key_len + val_len + 3;
+        size_t val_len = (unsigned char)msg[2] | ((unsigned char)msg[3] << 8);
+        size_t end_pos = key_len + val_len + 4;
         if (end_pos >= PROP_MSG_MAX)
             break;
 
-        const char* key = msg + 3;
+        const char* key = msg + 4;
         const char* value = key + key_len;
         len = kvdb_recv(fd, msg, len, end_pos);
         if (len > 0) {
@@ -465,7 +467,7 @@ static bool kvdb_client(kvdb_server* server, int fd)
 #ifdef CONFIG_KVDB_DUMPLIST
     case 'L': {
         kvdb_list(server->kvdb, kvdb_list_consume, (void*)(uintptr_t)fd);
-        send(fd, "\0", 2, 0); /* terminator */
+        send(fd, "\0\0", 3, 0); /* terminator: key_len=0 + 2-byte val_len=0 */
         break;
     }
 #endif


### PR DESCRIPTION
Encode val_len as 2 little-endian bytes in the client/server wire protocol and raise PROP_VALUE_MAX from 255 to 1024, so larger property values can be transferred.

*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

Update KVDB client/server protocol to support larger property values.

The original protocol uses 1-byte val_len, which limits property values
to 255 bytes. This patch changes val_len to 2-byte little-endian format
and increases PROP_VALUE_MAX from 255 to 1024.

This allows KVDB to transfer larger property values through the
client/server interface.

## Impact

- Increase maximum property value size from 255 to 1024 bytes.
- Client and server protocol format are changed, so both sides need to
  be updated together.
- No impact for existing property values smaller than 255 bytes.

## Testing

Tested KVDB client/server communication with:

- Property value size < 255 bytes
- Property value size > 255 bytes
- Property value size close to 1024 bytes

Verified that property set/get operations work correctly.

